### PR TITLE
Fix OS reporting in /system_stats API to use sys.platform

### DIFF
--- a/server.py
+++ b/server.py
@@ -558,7 +558,7 @@ class PromptServer():
 
             system_stats = {
                 "system": {
-                    "os": os.name,
+                    "os": sys.platform,
                     "ram_total": ram_total,
                     "ram_free": ram_free,
                     "comfyui_version": __version__,


### PR DESCRIPTION
## Summary
This PR updates the `/system_stats` API to use `sys.platform` instead of `os.name` for more accurate OS identification.

## Problem
Currently, the API uses `os.name` which returns:
- Windows: `"nt"`
- macOS: `"posix"`
- Linux: `"posix"`

This makes it impossible to distinguish between macOS and Linux systems.

## Solution
Switch to `sys.platform` which provides unique identifiers:
- Windows: `"win32"`
- macOS: `"darwin"`
- Linux: `"linux"`

## Benefits
- ✅ Each OS now has a unique identifier
- ✅ Aligns with Registry Specifications for proper compatibility checks
- ✅ Frontend can accurately determine OS for compatibility validation
- ✅ Tested on macOS (darwin), confirmed working

## Impact Analysis
- **Frontend**: Most code already uses `includes()` for OS checking, so it remains compatible
- **Test files**: May need to update mock data from `"posix"` to `"linux"` or `"darwin"`
- **Extensions**: Any code depending on exact `os.name` values needs updating

## Related Discussion
This change was discussed in Slack where it was confirmed that `sys.platform` correctly differentiates between all three major operating systems.

🤖 Generated with [Claude Code](https://claude.ai/code)